### PR TITLE
Reduce layout shift on the header

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,9 +1,6 @@
 import Link from "next/link"
-import { signIn, signOut, useSession } from "next-auth/react"
+import { useSession } from "next-auth/react"
 import { Session } from "../utils/types"
-import { Menu, Transition } from "@headlessui/react"
-import { Fragment } from "react"
-import classNames from "classnames"
 import { Logo } from "./Logo"
 import { Heart, TicketIcon } from "./Icons"
 
@@ -24,24 +21,24 @@ export default function Header() {
             <Logo />
           </a>
         </Link>
-        {!isLoading && (
-          <div className="flex gap-3">
-            <Link href="/donate">
-              <a className="bg-devs-yellow text-devs-black px-4 py-2 rounded-md font-normal text-xs flex gap-2 items-center">
-                <Heart width="20" />
-                Donate
+
+        <div className="flex gap-3">
+          {session?.user?.username && (
+            <Link href={`/tickets/${session?.user?.username}`}>
+              <a className="bg-devs-gray200 px-4 py-2 rounded-md font-normal text-xs gap-2 items-center hidden sm:flex">
+                <TicketIcon fill="white" width="20" />
+                Your ticket
               </a>
             </Link>
-            {session && (
-              <Link href={`/tickets/${session?.user?.username}`}>
-                <a className="bg-devs-gray200 px-4 py-2 rounded-md font-normal text-xs gap-2 items-center hidden sm:flex">
-                  <TicketIcon fill="white" width="20" />
-                  Your ticket
-                </a>
-              </Link>
-            )}
-          </div>
-        )}
+          )}
+
+          <Link href="/donate">
+            <a className="bg-devs-yellow text-devs-black px-4 py-2 rounded-md font-normal text-xs flex gap-2 items-center">
+              <Heart width="20" />
+              Donate
+            </a>
+          </Link>
+        </div>
       </div>
     </header>
   )

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -4,17 +4,19 @@ export default function Document() {
   return (
     <Html>
       <Head>
-        <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://rsms.me" crossOrigin="true" />
+
         <link
           rel="preconnect"
           href="https://fonts.gstatic.com"
-          crossOrigin={"true"}
+          crossOrigin="true"
         />
+
+        <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
         <link
           href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&display=swap"
           rel="stylesheet"
-        ></link>
+        />
       </Head>
       <body>
         <Main />


### PR DESCRIPTION
- Reduce layout shift on the header by putting the thing on the left of `Donate`. Also show `donate` at all times. 
- Add the other font domain to the preconnect list